### PR TITLE
Adding nickname, avatar, and victim to user

### DIFF
--- a/db/migrate/20210806005835_add_columns_to_users.rb
+++ b/db/migrate/20210806005835_add_columns_to_users.rb
@@ -1,0 +1,7 @@
+class AddColumnsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :nickname, :string
+    add_column :users, :avatar, :string
+    add_column :users, :victim, :boolean, default: true
+  end
+end


### PR DESCRIPTION
This commit has the following:

- Adding nickname, avatar, and victim to the User table

Reason being was that it is missing in the schema