### PR TITLE
Basic index page complete

### DIFF
--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -1,10 +1,37 @@
 .button-add {
-  // border-radius: 50%;
-  // height: 30px;
-  // width: 30px;
+  border-radius: 50%;
+  border: solid;
+  border-width: 5px;
+  height: 50px;
+  width: 50px;
+  font-size: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: $purple;
+  padding: 10px;
   position: fixed;
   right: 30px;
-  bottom: 150px;
+  bottom: 155px;
+  backdrop-filter: blur(2px);
+}
+
+.button-share {
+  border-radius: 50%;
+  border: solid;
+  border-width: 5px;
+  height: 50px;
+  width: 50px;
+  font-size: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: $purple;
+  padding: 10px;
+  position: fixed;
+  right: 30px;
+  bottom: 95px;
+  backdrop-filter: blur(2px);
 }
 
 .button-large {

--- a/app/assets/stylesheets/components/_incident.scss
+++ b/app/assets/stylesheets/components/_incident.scss
@@ -1,16 +1,56 @@
 .incident-card {
-
-  .incident-thumbnail {
-  height: 70px;
-  width: 70px;
-  // background-image: cover;
-  object-fit: cover;
+  box-shadow: 2px 2px 10px 2px rgba(0, 0, 0, 0.1);
+  border-radius: 5px;
+  a {
+    text-decoration: none;
+  }
+  h3 {
+    font-size: 18px;
+  }
+  p {
+    font-size: 12px;
   }
 
+  .incident-thumbnail {
+  height: 80px;
+  width: 80px;
+  border-radius: 5px 0 0 5px;
+  object-fit: cover;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+    .far {
+    font-size: 40px;
+    color: white;
+    }
+  }
+  .empty-thumbnail {
+  height: 80px;
+  width: 80px;
+  background-color: #788b9d;
+  border-radius: 5px 0 0 5px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+    .far {
+    font-size: 40px;
+    color: white;
+    }
+  }
 }
 
 .incidents {
- overflow-y: scroll;
+  overflow-y: scroll;
+ //  .incident-card:last-child {
+ //    margin-bottom: 60px;
+ // }
+ padding-bottom: 80px;
 }
 
+.title {
+  text-decoration: none;
+}
 
+.date {
+  text-decoration: none;
+}

--- a/app/views/pages/_incident-card.html.erb
+++ b/app/views/pages/_incident-card.html.erb
@@ -1,28 +1,40 @@
 <div class="incidents">
   <% incidents.each do |incident| %>
-    <div class="incident-card mx-3 mt-5 shadow d-flex">
+    <%= link_to incident_path(incident) do %>
+      <div class="incident-card mx-3 mt-4 d-flex">
 
-        <div>
-          <% if incident.attachment.attached? %>
-            <%= cl_image_tag incident.attachment.key, class: 'incident-thumbnail' %>
-          <%# else %>
-
-          <% end %>
-        </div>
-
-        <div class="incident-title-date">
-          <h3 class="title"> <%= incident.title %> </h3>
-          <div class="date d-flex">
-            <%= image_tag "calendar_today.svg", alt: "calendar icon" %>
-            <p> <%= incident.date.strftime('%a. %B %d, %Y') %> </p>
+          <div>
+            <% if incident.attachment.attached? %>
+              <div class= "incident-thumbnail" style="background-image: linear-gradient(rgba(0,0,0,0.2), rgba(0,0,0,0.2)), url( <%= cl_image_path incident.attachment.key, width: 80, height: 80, crop: :fill %> )">
+                <i class="far fa-images"></i>
+              </div>
+            <% else %>
+              <div class="empty-thumbnail">
+                <i class="far fa-images"></i>
+              </div>
+            <% end %>
           </div>
-        </div>
 
-        <p> 1 attach. </p>
+          <div class="incident-title-date mx-3 d-flex flex-column justify-content-around">
+            <h3 class="title pt-2 pb-1"> <%= incident.title %> </h3>
+            <div class="date d-flex pb-2">
+              <%= image_tag "calendar_today.svg", alt: "calendar icon", width: "18px", class: "mr-1" %>
+              <p> <%= incident.date.strftime('%a. %B %d, %Y') %> </p>
+            </div>
+          </div>
 
-    </div>
+  <!--         <p class=""> 1 attach. </p> -->
+
+      </div>
+    <% end %>
   <% end %>
 
-    <%= link_to "+", new_incident_path, class: "button-add" %>
+    <%= link_to new_incident_path do %>
+      <i class="fas fa-plus button-add"></i>
+    <% end %>
+
+    <%= link_to new_incident_path do %>
+      <i class="fas fa-share-alt button-share"></i>
+    <% end %>
 
 </div>


### PR DESCRIPTION
Updates to index page:
- new floating add and share buttons
- cleaned cards up, with cloudinary image thumbnail
- fixed spacing and margins
- Each card links to incident show page

Still needs work:
- Now that the cards are a link, their flex behaviour is weird and they don't span across the whole screen
- also can't get rid of the blue text colour, even after putting "text-decoration: none" literally everywhere
- the add button links to incidents#new, but the share button does not link to where it needs to go yet
<img width="377" alt="Screen Shot 2021-08-11 at 10 36 47 PM" src="https://user-images.githubusercontent.com/78288118/129038858-4b03e81a-e058-4a59-a190-0ac108b284a6.png">
